### PR TITLE
Fix dry-run mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,6 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Run Unit Tests
-        if: ${{ inputs.dry-run != 'true' }}
         run: |
           npm ci
           npm run test
@@ -101,7 +100,7 @@ jobs:
           title-regex: '^##\s+\[\d.*$'
 
       - name: Create a GitHub release
-        if: ${{ inputs.dry-run != 'true' }}
+        if: ${{ !inputs.dry-run }}
         uses: ncipollo/release-action@v1
         with:
           tag: 'v${{ steps.get-version.outputs.version }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ permissions:
 env:
   INPUTS_DRY_RUN: ${{ inputs.dry-run }}
   INPUTS_TAG: ${{ inputs.tag }}
-  DRY_RUN_OPTION: ${{ inputs.dry-run == 'true' || '' }}
+  DRY_RUN_OPTION: ${{ inputs.dry-run == 'true' && '--dry-run' || '' }}
 
 
 jobs:
@@ -85,7 +85,7 @@ jobs:
           npm run test
 
       - name: Publish to npm
-        run: npm publish --tag $INPUTS_TAG --access public $DRY_RUN_OPTION
+        run: npm publish --tag $INPUTS_TAG --access public $INPUTS_DRY_RUN
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ permissions:
 env:
   INPUTS_DRY_RUN: ${{ inputs.dry-run }}
   INPUTS_TAG: ${{ inputs.tag }}
-  DRY_RUN_OPTION: ${{ inputs.dry-run == 'true' && '--dry-run' || '' }}
 
 
 jobs:
@@ -85,7 +84,7 @@ jobs:
           npm run test
 
       - name: Publish to npm
-        run: npm publish --tag $INPUTS_TAG --access public $INPUTS_DRY_RUN
+        run: npm publish --tag $INPUTS_TAG --access public --dry-run $INPUTS_DRY_RUN
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ permissions:
 env:
   INPUTS_DRY_RUN: ${{ inputs.dry-run }}
   INPUTS_TAG: ${{ inputs.tag }}
-  DRY_RUN_OPTION: ${{ inputs.dry-run == 'true' && '--dry-run' || '' }}
+  DRY_RUN_OPTION: ${{ inputs.dry-run == 'true' || '' }}
 
 
 jobs:


### PR DESCRIPTION
With dry-run option set, this didn't work
- `npm publish` was called with `true` instead of `--dry-run true`
- GH release was created, caused by the `inputs-dry-run != 'true'` comparison not working.  Better is to use the `!` operator.