### PR TITLE
Add `cf-setup` reusable action

### DIFF
--- a/.github/cf-setup/action.yaml
+++ b/.github/cf-setup/action.yaml
@@ -1,11 +1,26 @@
 name: Cloud Foundry Setup
-description: "Installs the CF CLI and MBT"
+description: "Installs dependencies for Cloud Foundry deployment"
 
 inputs:
   cf-version:
     description: "The version of the Cloud Foundry CLI to install"
     required: false
     default: "8.8.3"
+  cf-api:
+    description: "The Cloud Foundry API endpoint to connect to"
+    required: true
+  cf-org:
+    description: "The Cloud Foundry organization to target"
+    required: true
+  cf-space:
+    description: "The Cloud Foundry space to target"
+    required: true
+  cf-username:
+    description: "The Cloud Foundry username to authenticate with"
+    required: true
+  cf-password:
+    description: "The Cloud Foundry password to authenticate with"
+    required: true
 
 runs:
   using: composite
@@ -13,18 +28,12 @@ runs:
     - shell: bash
       run: |
         set -e
-        CF_VERSION="${{ inputs.cf-version }}"
-        echo "Using CF_VERSION=$CF_VERSION"
-        echo "Using CF_API=$CF_API"
-
-    - shell: bash
-      run: |
-        CF_VERSION="${{ inputs.cf-version }}"
-        echo "Installing CF CLI $CF_VERSION..."
-        curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_VERSION}&source=github" -o cf-cli.tgz
+        echo "Using CF_VERSION=${{ inputs.cf-version }}"
+        echo "Using CF_API=${{ inputs.cf-api }}"
+        curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${{ inputs.cf-version }}&source=github" -o cf-cli.tgz
         mkdir cf-cli && tar -xzf cf-cli.tgz -C cf-cli
         chmod +x cf-cli/cf
-        sudo mv cf-cli/cf /usr/local/bin/cf
+        echo "${PWD}/cf-cli" >> $GITHUB_PATH
 
     - shell: bash
       run: |
@@ -39,6 +48,6 @@ runs:
     - shell: bash
       run: |
         echo "Authenticating to Cloud Foundry..."
-        cf api "$CF_API"
-        echo "$CF_PASSWORD" | cf auth "$CF_USERNAME"
-        cf target -o "$CF_ORG" -s "$CF_SPACE"
+        cf api "${{ inputs.cf-api }}"
+        cf auth "${{ inputs.cf-username }}" "${{ inputs.cf-password }}"
+        cf target -o "${{ inputs.cf-org }}" -s "${{ inputs.cf-space }}"

--- a/.github/cf-setup/action.yaml
+++ b/.github/cf-setup/action.yaml
@@ -1,0 +1,44 @@
+name: Cloud Foundry Setup
+description: "Installs the CF CLI and MBT"
+
+inputs:
+  cf-version:
+    description: "The version of the Cloud Foundry CLI to install"
+    required: false
+    default: "8.8.3"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -e
+        CF_VERSION="${{ inputs.cf-version }}"
+        echo "Using CF_VERSION=$CF_VERSION"
+        echo "Using CF_API=$CF_API"
+
+    - shell: bash
+      run: |
+        CF_VERSION="${{ inputs.cf-version }}"
+        echo "Installing CF CLI $CF_VERSION..."
+        curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_VERSION}&source=github" -o cf-cli.tgz
+        mkdir cf-cli && tar -xzf cf-cli.tgz -C cf-cli
+        chmod +x cf-cli/cf
+        sudo mv cf-cli/cf /usr/local/bin/cf
+
+    - shell: bash
+      run: |
+        echo "Installing MBT..."
+        npm install -g mbt
+
+    - shell: bash
+      run: |
+        echo "Installing CF CLI multiapps plugin..."
+        cf install-plugin multiapps -f
+
+    - shell: bash
+      run: |
+        echo "Authenticating to Cloud Foundry..."
+        cf api "$CF_API"
+        echo "$CF_PASSWORD" | cf auth "$CF_USERNAME"
+        cf target -o "$CF_ORG" -s "$CF_SPACE"


### PR DESCRIPTION
This is the one used in `cds add github-actions`. Might ship this later to the GHA marketplace, so all users need to do is reference `cap-js/cf-setup`.