### PR TITLE
Enable trusted publishing w/o NPM token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
 
       - name: Run Unit Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,8 +85,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --tag $INPUTS_TAG --access public --provenance --dry-run $INPUTS_DRY_RUN
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 
       - name: Get Version
         id: get-version


### PR DESCRIPTION
Token is obsolete if trusted publishing is enabled:
https://docs.npmjs.com/trusted-publishers
