### PR TITLE
Use latest NPM version for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
 
       - name: Run Unit Tests


### PR DESCRIPTION
Otherwise [trusted publishing](https://docs.npmjs.com/trusted-publishers) would fail.